### PR TITLE
Use http-server flag to disable caching

### DIFF
--- a/watch.js
+++ b/watch.js
@@ -24,4 +24,4 @@ function cmd(program, args) {
 }
 
 cmd('tsc', ['-w'])
-cmd('http-server', ['-p', '6969', '-a', '127.0.0.1', '-s'])
+cmd('http-server', ['-p', '6969', '-a', '127.0.0.1', '-s', '-c-1'])


### PR DESCRIPTION
`http-server` has a flag (`-c`) which allows for fine grained control over caching. By setting that flag to `-1`, it disables caching altogether. This PR adds that flag to `watch.js`. Note: The first time you run it you may still need to do reload with the devtools open to ensure you get the latest version of `index.js` with the correct headers.