### PR TITLE
A few improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,6 +331,7 @@ function renderWallsToImageData(imageData, player, scene) {
         else if (cell instanceof ImageData) {
             const v = p.sub(player.position);
             const d = Vector2.angle(player.direction);
+            const k = v.dot(d);
             const stripHeight = SCREEN_HEIGHT / v.dot(d);
             let u = 0;
             const t = p.sub(c);
@@ -343,11 +344,11 @@ function renderWallsToImageData(imageData, player, scene) {
             for (let dy = 0; dy < Math.ceil(stripHeight); ++dy) {
                 const tx = Math.floor(u * cell.width);
                 const ty = Math.floor(dy / Math.ceil(stripHeight) * cell.height);
+                const ti = (ty * cell.width + tx) * 4;
                 const y = Math.floor((SCREEN_HEIGHT - stripHeight) * 0.5) + dy;
-                imageData.data[(y * SCREEN_WIDTH + x) * 4 + 0] = cell.data[(ty * cell.width + tx) * 4 + 0] / v.dot(d);
-                imageData.data[(y * SCREEN_WIDTH + x) * 4 + 1] = cell.data[(ty * cell.width + tx) * 4 + 1] / v.dot(d);
-                imageData.data[(y * SCREEN_WIDTH + x) * 4 + 2] = cell.data[(ty * cell.width + tx) * 4 + 2] / v.dot(d);
-                imageData.data[(y * SCREEN_WIDTH + x) * 4 + 3] = cell.data[(ty * cell.width + tx) * 4 + 3];
+                const i = (y * SCREEN_WIDTH + x) * 4;
+                if (i > 0 && i < imageData.data.length - 5)
+                    imageData.data.set(cell.data.subarray(ti, ti + 4).map((v, i) => i < 3 ? v / k : v), i);
             }
         }
     }
@@ -411,7 +412,7 @@ function renderGameIntoImageData(ctx, backCtx, backImageData, deltaTime, player,
     renderMinimap(ctx, player, minimapPosition, minimapSize, scene);
     ctx.font = "48px bold";
     ctx.fillStyle = "white";
-    ctx.fillText(`${Math.round(fps)}`, 100, 100);
+    ctx.fillText(`${Math.round(fps * 10) / 10}`, 100, 100);
 }
 function loadImage(url) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/index.ts
+++ b/index.ts
@@ -356,6 +356,7 @@ function renderWallsToImageData(imageData: ImageData, player: Player, scene: Sce
         } else if (cell instanceof ImageData) {
             const v = p.sub(player.position);
             const d = Vector2.angle(player.direction)
+            const k = v.dot(d);
             const stripHeight = SCREEN_HEIGHT/v.dot(d);
 
             let u = 0;
@@ -369,12 +370,12 @@ function renderWallsToImageData(imageData: ImageData, player: Player, scene: Sce
             for (let dy = 0; dy < Math.ceil(stripHeight); ++dy) {
                 const tx = Math.floor(u*cell.width);
                 const ty = Math.floor(dy/Math.ceil(stripHeight)*cell.height);
+                const ti = (ty*cell.width + tx)*4;
 
                 const y = Math.floor((SCREEN_HEIGHT - stripHeight)*0.5) + dy;
-                imageData.data[(y*SCREEN_WIDTH + x)*4 + 0] = cell.data[(ty*cell.width + tx)*4 + 0]/v.dot(d);
-                imageData.data[(y*SCREEN_WIDTH + x)*4 + 1] = cell.data[(ty*cell.width + tx)*4 + 1]/v.dot(d);
-                imageData.data[(y*SCREEN_WIDTH + x)*4 + 2] = cell.data[(ty*cell.width + tx)*4 + 2]/v.dot(d);
-                imageData.data[(y*SCREEN_WIDTH + x)*4 + 3] = cell.data[(ty*cell.width + tx)*4 + 3];
+                const i = (y*SCREEN_WIDTH + x)*4;
+                if (i > 0 && i < imageData.data.length-5)
+                    imageData.data.set(cell.data.subarray(ti,ti+4).map((v,i)=>i<3?v/k:v),i);
             }
         }
     }
@@ -448,7 +449,7 @@ function renderGameIntoImageData(ctx: CanvasRenderingContext2D, backCtx: Offscre
 
     ctx.font = "48px bold"
     ctx.fillStyle = "white"
-    ctx.fillText(`${Math.round(fps)}`, 100, 100);
+    ctx.fillText(`${Math.round(fps*10)/10}`, 100, 100);
 }
 
 async function loadImage(url: string): Promise<HTMLImageElement> {


### PR DESCRIPTION
## Added FPS smoothing with a rolling average
- Creates an array, and the current FPS is pushed to the front for each frame, and then the array gets resized to `FPS_SMOOTHING` elements
- Note: This was made for 'accuracy', but it is not really optimal, a better way of doing this would be to have the array initialized with `FPS_SMOOTHING` elements, but the FPS counter would not be accurate before `FPS_SMOOTHING` frames have passed - although that might not really be a probem

## Slightly improved renderWallsToImageData performance
- The brightness computation is now done only once per stripe for the textures
- And the data is written using `Uint8ClampedArray.set`, which is apparently a bit faster, not sure if that would be even better with more CPU/RAM usage