### PR TITLE
[watch] use npx in to run npm dependencies

### DIFF
--- a/watch.js
+++ b/watch.js
@@ -23,5 +23,5 @@ function cmd(program, args) {
     return p;
 }
 
-cmd('tsc', ['-w'])
-cmd('http-server', ['-p', '6969', '-a', '127.0.0.1', '-s', '-c-1'])
+cmd('npx', ['tsc', '-w'])
+cmd('npx', ['http-server', '-p', '6969', '-a', '127.0.0.1', '-s', '-c-1'])


### PR DESCRIPTION
obviously `tsc` in not everyone's `PATH`. a fix for that is running it with `npx`, to ensure it search through node_modules/
(one should have run `npm i` first)
related to issues on windows? like in #3  ?

