### PR TITLE
Make image-data walls glow with distance

### DIFF
--- a/game.js
+++ b/game.js
@@ -370,14 +370,14 @@ function renderWallsToImageData(imageData, player, scene) {
             const by2 = Math.min(imageData.height - 1, y2);
             const tx = Math.floor(u * cell.width);
             const sh = (1 / Math.ceil(stripHeight)) * cell.height;
-            const shadow = 1 / v.dot(d) * 2;
+            const glow = v.dot(d) / 2;
             for (let y = by1; y <= by2; ++y) {
                 const ty = Math.floor((y - y1) * sh);
                 const destP = (y * imageData.width + x) * 4;
                 const srcP = (ty * cell.width + tx) * 4;
-                imageData.data[destP + 0] = cell.data[srcP + 0] * shadow;
-                imageData.data[destP + 1] = cell.data[srcP + 1] * shadow;
-                imageData.data[destP + 2] = cell.data[srcP + 2] * shadow;
+                imageData.data[destP + 0] = cell.data[srcP + 0] * glow;
+                imageData.data[destP + 1] = cell.data[srcP + 1] * glow;
+                imageData.data[destP + 2] = cell.data[srcP + 2] * glow;
             }
         }
     }

--- a/game.ts
+++ b/game.ts
@@ -416,14 +416,14 @@ function renderWallsToImageData(imageData: ImageData, player: Player, scene: Sce
             const by2 = Math.min(imageData.height-1, y2);
             const tx = Math.floor(u*cell.width);
             const sh = (1/Math.ceil(stripHeight))*cell.height;
-            const shadow = 1/v.dot(d)*2;
+            const glow = v.dot(d)/2;
             for (let y = by1; y <= by2; ++y) {
                 const ty = Math.floor((y - y1)*sh);
                 const destP = (y*imageData.width + x)*4;
                 const srcP = (ty*cell.width + tx)*4;
-                imageData.data[destP + 0] = cell.data[srcP + 0]*shadow;
-                imageData.data[destP + 1] = cell.data[srcP + 1]*shadow;
-                imageData.data[destP + 2] = cell.data[srcP + 2]*shadow;
+                imageData.data[destP + 0] = cell.data[srcP + 0]*glow;
+                imageData.data[destP + 1] = cell.data[srcP + 1]*glow;
+                imageData.data[destP + 2] = cell.data[srcP + 2]*glow;
             }
         }
     }


### PR DESCRIPTION
Making the image-data walls darken with distance doesn't seem to match the lighting of ceiling and floors.

BEFORE:
<img src="https://github.com/tsoding/raycasting/assets/41588684/7fc34889-0067-44ed-94e1-f5861744e9d5" width="600px" height="350px"/>

AFTER:
<img src="https://github.com/tsoding/raycasting/assets/41588684/534823ca-224b-4085-882f-b3160b47be6d" width="600px" height="350px" />
