### PR TITLE
Move reading and updating DataViews to methods of corresponding classes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/common.mjs
+++ b/common.mjs
@@ -222,6 +222,35 @@ export var Moving;
     Moving[Moving["TurningRight"] = 3] = "TurningRight";
     Moving[Moving["Count"] = 4] = "Count";
 })(Moving || (Moving = {}));
+export class PlayerClass {
+    id;
+    position;
+    direction;
+    moving = 0;
+    hue;
+    constructor(id, x, y, direction, moving, hue) {
+        this.id = id;
+        this.position = new Vector2(x, y);
+        this.direction = direction;
+        this.moving = moving;
+        this.hue = hue / 256 * 360;
+    }
+    fromDataView(view, structType) {
+        this.id = structType.id.read(view);
+        this.position = new Vector2(structType.x.read(view), structType.y.read(view));
+        this.direction = structType.direction.read(view);
+        this.hue = structType.hue.read(view) / 256 * 360;
+        if ('moving' in structType) {
+            this.moving = structType.moving.read(view);
+        }
+    }
+    update(other) {
+        this.direction = other.direction;
+        this.hue = other.hue;
+        this.position = other.position;
+        this.moving = other.moving;
+    }
+}
 export var MessageKind;
 (function (MessageKind) {
     MessageKind[MessageKind["Hello"] = 0] = "Hello";

--- a/common.mts
+++ b/common.mts
@@ -235,6 +235,37 @@ export interface Player {
     hue: number,
 }
 
+export class PlayerClass implements Player {
+    id: number;
+    position: Vector2;
+    direction: number;
+    moving: number = 0;
+    hue: number;
+
+    constructor(id: number, x: number, y: number, direction: number, moving: number, hue: number) {
+        this.id = id;
+        this.position = new Vector2(x, y);
+        this.direction = direction;
+        this.moving = moving;
+        this.hue = hue / 256 * 360
+    }
+    fromDataView(view: DataView, structType: typeof HelloStruct | typeof PlayerStruct) {
+        this.id = structType.id.read(view);
+        this.position = new Vector2(structType.x.read(view), structType.y.read(view));
+        this.direction = structType.direction.read(view);
+        this.hue = structType.hue.read(view) / 256 * 360;
+        if ('moving' in structType) {  // TODO: this hack exist only because HelloStruct doesn't have 'moving' property
+            this.moving = structType.moving.read(view);
+        }
+    }
+    update(other: PlayerClass): void {
+        this.direction = other.direction;
+        this.hue = other.hue;
+        this.position = other.position;
+        this.moving = other.moving;
+    }
+}
+
 export enum MessageKind {
     Hello,
     PlayerJoined,


### PR DESCRIPTION
In the current codebase, infrastructure operations (namely, reading and writing values from data structures) are directly integrated into the game logic. I was wondering if you'd be open to decoupling some of the protocol-related functionality from the game logic.

This pull request introduces two new classes: PlayerClass and PlayerOnServerClass, which handle reading from and writing to WebSockets. This reduces code repetition and slightly improves readability. Additionally, by separating these concerns, it opens the door for future extensions - such as supporting other transport mechanisms besides WebSockets.

There are a couple of hacks included in this PR, as the current toDataView and fromDataView methods accept different structures with non-overlapping sets of fields. However, this can be addressed by introducing structure-specific logic within the methods.